### PR TITLE
move function is almost ready.

### DIFF
--- a/assignment_project/Assets/Scripts/Commands.meta
+++ b/assignment_project/Assets/Scripts/Commands.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1d0ad2b2361208c43b4a1e95453650b1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/assignment_project/Assets/Scripts/Commands/ICommand.cs
+++ b/assignment_project/Assets/Scripts/Commands/ICommand.cs
@@ -1,0 +1,7 @@
+namespace TileGame
+{
+    public interface ICommand
+    {
+        int Execute();
+    }
+}

--- a/assignment_project/Assets/Scripts/Commands/ICommand.cs.meta
+++ b/assignment_project/Assets/Scripts/Commands/ICommand.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 77e9f8ba719b6764aa9d566fa15c0aac
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/assignment_project/Assets/Scripts/Commands/MoveCommand.cs
+++ b/assignment_project/Assets/Scripts/Commands/MoveCommand.cs
@@ -1,0 +1,21 @@
+using TileGame.Player;
+
+namespace TileGame
+{
+    public class MoveCommand : ICommand
+    {
+        private PlayerController player;
+        private int tileEndIndex;
+
+        public MoveCommand(PlayerController _player, int tileEndIndex)
+        {
+            player = _player;
+            this.tileEndIndex = tileEndIndex;
+        }
+
+        public int Execute()
+        {
+            return player.MovePlayer(tileEndIndex);
+        }
+    }
+}

--- a/assignment_project/Assets/Scripts/Commands/MoveCommand.cs.meta
+++ b/assignment_project/Assets/Scripts/Commands/MoveCommand.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: adcec28f9c96c8942afebce71cb4343b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/assignment_project/Assets/Scripts/Misc/Enums.cs
+++ b/assignment_project/Assets/Scripts/Misc/Enums.cs
@@ -13,4 +13,10 @@ namespace TileGame
         MoveRight = 1,
         MoveLeft = -1,
     }
+
+    public enum PowerCardType
+    {
+        MoveBackward,
+        Imprison
+    }
 }

--- a/assignment_project/Assets/Scripts/Player/MVC/PlayerController.cs
+++ b/assignment_project/Assets/Scripts/Player/MVC/PlayerController.cs
@@ -26,5 +26,36 @@ namespace TileGame.Player
             position.x = xPos;
             PlayerView.transform.position = position;
         }
+
+        public int MovePlayer(int tileEndIndex)
+        {
+            int moveDir = (int)PlayerModel.MoveDirection;
+            PlayerModel.TilePosition += moveDir;
+            if (PlayerModel.TilePosition == 0 || PlayerModel.TilePosition == tileEndIndex)
+            {
+                moveDir *= -1;
+                PlayerModel.MoveDirection = (PlayerMoveDirection)moveDir;
+            }
+            return PlayerModel.TilePosition;
+        }
+
+        public void ApplyPowerCard(PowerCardType cardType, int powerCardInt)
+        {
+            switch (cardType)
+            {
+                case PowerCardType.MoveBackward:
+                    {
+                        // move backwards 
+                        break;
+                    }
+                case PowerCardType.Imprison:
+                    {
+                        // imprison the player for two turns
+                        break;
+                    }
+            }
+
+
+        }
     }
 }

--- a/assignment_project/Assets/Scripts/Player/PowerCards.meta
+++ b/assignment_project/Assets/Scripts/Player/PowerCards.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6b6f2a092dc088b49bc10687a7d44cd5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/assignment_project/Assets/Scripts/Player/PowerCards/PowerCardsBase.cs
+++ b/assignment_project/Assets/Scripts/Player/PowerCards/PowerCardsBase.cs
@@ -1,0 +1,34 @@
+using TileGame.Player;
+using UnityEngine;
+
+namespace TileGame
+{
+    public abstract class PowerCardsBase : ScriptableObject
+    {
+        public string cardName;
+        public PowerCardType cardType;
+        public abstract void ApplyEffect(PlayerController player);
+    }
+
+    [CreateAssetMenu(fileName = "Backward Power Card", menuName = "Power Cards/Backwards")]
+    public class BackwardsPowerCard : PowerCardsBase
+    {
+        public int backwardDirection = -1;
+
+        public override void ApplyEffect(PlayerController player)
+        {
+            player.ApplyPowerCard(cardType, backwardDirection);
+        }
+    }
+
+    [CreateAssetMenu(fileName = "Imprison Power Card", menuName = "Power Cards/Imprison")]
+    public class ImprisonPowerCard : PowerCardsBase
+    {
+        public int imprisonTurns = 2;
+
+        public override void ApplyEffect(PlayerController player)
+        {
+            player.ApplyPowerCard(cardType, imprisonTurns);
+        }
+    }
+}

--- a/assignment_project/Assets/Scripts/Player/PowerCards/PowerCardsBase.cs.meta
+++ b/assignment_project/Assets/Scripts/Player/PowerCards/PowerCardsBase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b0f59239024f34d468d42109d9b34554
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/assignment_project/Assets/Scripts/Services/GameManager.cs
+++ b/assignment_project/Assets/Scripts/Services/GameManager.cs
@@ -82,30 +82,18 @@ namespace TileGame.MainGame
             currentPlayerTurn = playersList[turnIndex % numOfPlayers];
 
             // MOVE function
-            // change tilePos value in PM
-            int currentTilePos = currentPlayerTurn.PlayerModel.TilePosition;
-            int moveDirection = (int)currentPlayerTurn.PlayerModel.MoveDirection;
-            int newTilePos = currentTilePos + (moveDirection * diceValue);
-            if (newTilePos > totalTiles - 1)
-            {
-                moveDirection *= -1;
-                currentPlayerTurn.PlayerModel.MoveDirection = (PlayerMoveDirection)moveDirection;
-                int offset = newTilePos - (totalTiles - 1);
-                newTilePos = totalTiles - 1 - offset;
-            }
-            if (newTilePos < 0)
-            {
-                moveDirection *= -1;
-                currentPlayerTurn.PlayerModel.MoveDirection = (PlayerMoveDirection)moveDirection;
-                int offset = newTilePos;
-                newTilePos = 0 + offset * -1;
-            }
+            ICommand moveCommand = new MoveCommand(currentPlayerTurn, totalTiles - 1);
 
-            currentPlayerTurn.PlayerModel.TilePosition = newTilePos;
-            // get value of tile from tile list
-            currentTilePosition.x = tileListController.GetTilePositionX(currentPlayerTurn.PlayerModel.TilePosition);
-            // move transform value
-            currentPlayerTurn.MoveCurrentPosition(currentTilePosition.x);
+            for (int i = 0; i < diceValue; i++)
+            {
+                int tilePos = moveCommand.Execute();
+
+                // these functions can be removed if invoking action from tile position 
+                // value change in PlayerModel... would require hard ref in PController
+                // or by making GameManager global access via singleton
+                currentTilePosition.x = tileListController.GetTilePositionX(tilePos);
+                currentPlayerTurn.MoveCurrentPosition(currentTilePosition.x);
+            }
 
             turnIndex++;
 


### PR DESCRIPTION
- ICommand interface created to test out the command pattern on move function first.
- added MoveCommand to be used inside PlayTurn function of gameManager, removed previous moving functionality as it was more complex and unneccessary. now calling movePlayer inside a for loop to get the same movement of the dice value rolled.
- added base definitions for power cards.
- MovePlayer functionality shifted to its correct location inside PlayerController